### PR TITLE
Fix token repository selection in main

### DIFF
--- a/cmd/token-guard/main.go
+++ b/cmd/token-guard/main.go
@@ -38,16 +38,17 @@ func main() {
 
 	// Choose TokenRepository implementation based on environment variable
 	var tokenRepo repository.TokenRepository
-	if cfg.TokenStore == "redis" {
+	switch cfg.TokenStore {
+	case "redis":
 		tokenRepo, err = repository.NewRedisTokenRepository(cfg.RedisAddress, cfg.RedisPassword)
-	} else if cfg.TokenStore == "inmemory" {
+		if err != nil {
+			log.Fatal("Failed to create token repository:", err)
+		}
+		log.Println("Redis token repository initialized.")
+	case "inmemory":
 		tokenRepo = repository.NewInMemoryTokenRepository()
-	}
-	if err != nil {
-		log.Fatal("Failed to create token repository:", err)
-	} else if cfg.TokenStore == "inmemory" {
 		log.Println("In-memory token repository initialized.")
-	} else {
+	default:
 		log.Fatalf("Invalid TOKEN_STORE environment variable: %s. Must be 'redis' or 'inmemory'.", cfg.TokenStore)
 	}
 


### PR DESCRIPTION
## Summary
- handle redis and in-memory token stores explicitly with switch
- log invalid token store only for unknown values

## Testing
- `go test ./...` *(no output, terminated)*
- `env PORT=8080 REDIS_ADDRESS=localhost:6379 REDIS_PASSWORD= JWT_SECRET=mysecret TOKEN_STORE=redis go run ./cmd/token-guard` *(fails to connect to redis but no invalid token store error)*

------
https://chatgpt.com/codex/tasks/task_e_68959335f2ac8330b28c7a90eab233b8