### PR TITLE
Centralize bearer token parsing and improve auth tests

### DIFF
--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -1,0 +1,16 @@
+package handler
+
+import (
+	"fmt"
+	"strings"
+)
+
+// extractBearerToken validates an Authorization header and returns the bearer token.
+// It ensures the header has the expected "Bearer " prefix and strips it.
+func extractBearerToken(authHeader string) (string, error) {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(authHeader, prefix) {
+		return "", fmt.Errorf("invalid authorization header")
+	}
+	return strings.TrimPrefix(authHeader, prefix), nil
+}

--- a/internal/handler/middleware.go
+++ b/internal/handler/middleware.go
@@ -21,10 +21,14 @@ func AuthMiddleware(tokenService *service.TokenService) func(next http.Handler) 
 				return
 			}
 
-			// JWT has "Bearer " prefix
-			tokenString := authHeader[len("Bearer "):]
+			tokenString, err := extractBearerToken(authHeader)
+			if err != nil {
+				log.Printf("AuthMiddleware: %v", err)
+				http.Error(w, err.Error(), http.StatusUnauthorized)
+				return
+			}
 
-			_, err := tokenService.ValidateToken(r.Context(), tokenString)
+			_, err = tokenService.ValidateToken(r.Context(), tokenString)
 			if err != nil {
 				log.Printf("AuthMiddleware: Invalid token: %v", err)
 				http.Error(w, fmt.Sprintf("Invalid token: %v", err), http.StatusUnauthorized)

--- a/internal/handler/middleware_test.go
+++ b/internal/handler/middleware_test.go
@@ -1,0 +1,30 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthMiddleware_InvalidPrefixAndMissingHeader(t *testing.T) {
+	t.Run("missing header", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		rr := httptest.NewRecorder()
+		mw := AuthMiddleware(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		mw.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+		assert.Equal(t, "Authorization header required\n", rr.Body.String())
+	})
+
+	t.Run("invalid prefix", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "Token abc")
+		rr := httptest.NewRecorder()
+		mw := AuthMiddleware(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		mw.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+		assert.Equal(t, "invalid authorization header\n", rr.Body.String())
+	})
+}


### PR DESCRIPTION
## Summary
- add helper to validate and strip "Bearer " prefix
- use helper in auth handlers and middleware
- add tests for missing or invalid authorization header prefixes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68959793d0d0833085c065f8ab8c4fa6