### PR TITLE
Ensure proper JSON headers in auth handlers

### DIFF
--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -72,8 +72,8 @@ func (h *AuthHandler) RegisterHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)                                                       // 201 Created
 	w.Header().Set("Content-Type", "application/json")                                      // Set Content-Type
+	w.WriteHeader(http.StatusCreated)                                                       // 201 Created
 	json.NewEncoder(w).Encode(map[string]string{"message": "User registered successfully"}) // JSON response
 	log.Println("RegisterHandler: User registered successfully")
 }
@@ -224,10 +224,9 @@ func (h *AuthHandler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("could not log out: %v", err), http.StatusUnauthorized)
 		return
 	}
+	w.Header().Set("Content-Type", "application/json") // Set Content-Type
 	w.WriteHeader(http.StatusOK)
-	w.Header().Set("Content-Type", "application/json")                                      // Set Content-Type
 	json.NewEncoder(w).Encode(map[string]string{"message": "User logged out successfully"}) // JSON response
-	fmt.Fprintln(w, "Logged out successfully")
 	log.Println("LogoutHandler: Logged out successfully")
 }
 

--- a/internal/handler/auth_handler_test.go
+++ b/internal/handler/auth_handler_test.go
@@ -102,6 +102,7 @@ func TestAuthHandler_RegisterHandler(t *testing.T) {
 	handler.RegisterHandler(recorder, req)
 
 	assert.Equal(t, http.StatusCreated, recorder.Code)
+	assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
 	assert.Equal(t, "{\"message\":\"User registered successfully\"}\n", recorder.Body.String())
 
 	// Reset the mock for the next test case!  This is important.
@@ -269,6 +270,8 @@ func TestAuthHandler_LogoutHandler(t *testing.T) {
 	handler.LogoutHandler(recorder, req)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+	assert.Equal(t, "{\"message\":\"User logged out successfully\"}\n", recorder.Body.String())
 	mockTokenService.AssertExpectations(t)
 
 	// Reset mocks before next test case


### PR DESCRIPTION
## Summary
- Set `Content-Type` header before sending status in register and logout handlers
- Remove extraneous text output from logout handler
- Verify response headers and bodies in auth handler tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689599576fc083309002dffe2866d074